### PR TITLE
Feature voting persistence

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -36,7 +36,8 @@ function App() {
 
     setMovies(updatedMovies)
 
-    //As a final step, we need to update the API
+    //Update the API and ensure vote count changed correctly
+    //NOTE: in order for vote count to persist between refresh, moviePosters must be fetched from API first (perhaps only at mount?)
     let direction = ""
     if (delta > 0) {
       direction = "up"
@@ -59,7 +60,9 @@ function App() {
   }
 
   function verifyVoteCountChange(old_count, new_count, delta) {
-    //Check that it changed by exactly delta; if not, log an error
+    if (new_count !== old_count + delta) {
+      console.log("Error: server/client: vote count did not update correctly relative to old value.")
+    }
   }
   
   return (

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -33,6 +33,27 @@ function App() {
     }, [])
 
     setMovies(updatedMovies)
+
+    //As a final step, we need to update the API
+    let direction = ""
+    if (delta > 0) {
+      direction = "up"
+    } else if (delta < 0) {
+      direction = "down"
+    } else {
+      console.log("Error: invalid vote change.")
+    }
+
+    const parameters = {
+      method: "PATCH",
+      body: JSON.stringify({ vote_direction: direction }),
+      headers: { "Content-Type": "application/json" }
+    }
+
+    fetch(`https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies/${moviePosterId}`, parameters)
+      .then(response => response.json())
+      .then(data => console.log("Response JSON data: ", data))
+      .catch(error => console.log("Error response: ", error))
   }
   
   return (

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -23,8 +23,10 @@ function App() {
   const updateVoteCount = (moviePosterId, delta) => {
     //Is there a quicker way to do this?  Would prefer to do a .find, update the key/value of that element, then just set the array
     //NOTE: optional - ensure that vount count cannot be negative
+    let old_vote_count = 0
     const updatedMovies = movies.reduce((acc, movie) => {
       if (movie.id === moviePosterId) {
+        old_vote_count = movie.vote_count
         movie.vote_count += delta
       }
 
@@ -41,7 +43,7 @@ function App() {
     } else if (delta < 0) {
       direction = "down"
     } else {
-      console.log("Error: invalid vote change.")
+      console.log("Error: client: invalid vote change.")
     }
 
     const parameters = {
@@ -52,8 +54,12 @@ function App() {
 
     fetch(`https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies/${moviePosterId}`, parameters)
       .then(response => response.json())
-      .then(data => console.log("Response JSON data: ", data))
-      .catch(error => console.log("Error response: ", error))
+      .then(data => verifyVoteCountChange(old_vote_count, data.vote_count, delta))
+      .catch(error => console.log(error))
+  }
+
+  function verifyVoteCountChange(old_count, new_count, delta) {
+    //Check that it changed by exactly delta; if not, log an error
   }
   
   return (


### PR DESCRIPTION
This branch implements voting persistence.  Specifically:
- When a user upvotes/downvotes, a PATCH API / fetch call is made to properly update the server (in addition to the client already updating via 'movies' state var)
- The fetch call ensures promises are resolved, including that the vote changes exactly by the amount expected; otherwise appropriate error is returned

NOTE: in order to truly function properly - namely, for the vote count to display correctly and persist between page refreshes - this will require the corresponding GET API / fetch call for the other user stories in this iteration.  Patrick and I will coordinate PRs together to ensure all functionality comes together.