### PR TITLE
Testing cypress voting tests

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -85,6 +85,20 @@ describe('Main Page', () => {
       cy.get('.movie-poster').eq(posterIndex).find('#down-vote').should('have.class', 'vote-button')
         .click().get('.movie-poster').eq(posterIndex).find('.vote-count').should('have.text', posters[posterIndex].vote_count - 1)
     })
+
+    it('sad path: movie id does not exist', () => {
+      //How would I implement this in any fancier way?  Stubbing seems silly (we're setting it up to fail on purpose);
+      //and hitting the real API isn't ideal (though it doesn't change votes at least).
+      //For now, hitting the real API:
+      cy.request({
+        url: "https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies",
+        method: "PATCH",
+        body: { "vote_direction": "up" },
+        failOnStatusCode: false
+      }).then(response => {
+        expect(response.status).to.eq(404)
+      })
+    })
     
     //More tests to implement:
     // - sad path: invalid movie id

--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -70,9 +70,23 @@ describe('Main Page', () => {
       cy.get('.movie-poster').eq(posterIndex).find('#up-vote').should('have.class', 'vote-button')
         .click().get('.movie-poster').eq(posterIndex).find('.vote-count').should('have.text', posters[posterIndex].vote_count + 1)
     })
+
+    it('can downvote to decrease vote count by one', () => {
+      const posterIndex = 1
+      const updatedPoster = changePosterVoteCount(posterIndex, -1)
+
+      cy.get('.movie-container').get('.movie-poster').eq(posterIndex).find('.vote-count').should('have.text', posters[posterIndex].vote_count)
+  
+      cy.intercept("PATCH", `/api/v1/movies/${posters[posterIndex].id}`, {
+        statusCode: 200,
+        body: updatedPoster
+      })
+  
+      cy.get('.movie-poster').eq(posterIndex).find('#down-vote').should('have.class', 'vote-button')
+        .click().get('.movie-poster').eq(posterIndex).find('.vote-count').should('have.text', posters[posterIndex].vote_count - 1)
+    })
     
     //More tests to implement:
-    // - downvote by one
     // - sad path: invalid movie id
     // - upvote + downvote combo is correct; also does not disturb another movie's stats
     // - sad path: MAYBE - incorrect PATH body gives error.  Note: wouldn't this require an actual API call to really be sure?...

--- a/src/MoviePoster/MoviePoster.js
+++ b/src/MoviePoster/MoviePoster.js
@@ -8,11 +8,11 @@ function MoviePoster({ id, posterPath, voteCount, title, getMovieDetails, update
       <button className='details-button' onClick={getMovieDetails}><img src={posterPath} alt={`${title} poster`}></img></button>
       <h3>{title}</h3>
       <p>
-        <button class='vote-button' onClick = {() => updateVoteCount(id, 1)}><img class='movie-poster-button-icons' src={upvoteIcon} alt="up-arrow"></img></button>
+        <button class='vote-button' id='up-vote' onClick = {() => updateVoteCount(id, 1)}><img class='movie-poster-button-icons' src={upvoteIcon} alt="up-arrow"></img></button>
         <div class='vote-count'>
           {voteCount}
         </div>
-        <button class='vote-button' onClick = {() => updateVoteCount(id, -1)}><img class='movie-poster-button-icons' src={downvoteIcon} alt="down-arrow"></img></button>
+        <button class='vote-button' id='down-vote' onClick = {() => updateVoteCount(id, -1)}><img class='movie-poster-button-icons' src={downvoteIcon} alt="down-arrow"></img></button>
       </p>
     </div>
   );


### PR DESCRIPTION
Cypress is implemented to test voting functionality.  Specifically:
- Simulated upvoting - when user clicks on upvote button, a PATCH API call is registered (and stubbed) and vote count increases by one
- Simulated downvoting - same as upvoting, but vote count decreases by one
- Sad path: if movie id does not exist, returns appropriate code.

Notes: there may be other (sad) paths to consider - such as not having negative votes - but these are presently not obvious or required.  Plan to discuss.

Type of change
  - [X] New feature
  - [ ] Bug Fix

Check the correct boxes
  - [X] This code broke nothing
  - [ ] This code broke some stuff
  - [ ] This code broke everything

Testing Changes:
  - [X] I have fully tested my code 
  - [X] All tests are passing
  - [ ] Some tests are failing
  - [ ] All tests are failing

  - [ ] No previous tests have been changed
  - [X] Some previous tests have been changed
  - [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

Checklist:
  - [X] I have reviewed my code
  - [X] The code will run locally
  - [ ] My code has no unused/commented out code
  - [X] I have commented my code, particularly in hard-to-understand areas